### PR TITLE
ci: add per-deck matrix build gate on PRs

### DIFF
--- a/.github/scripts/list-talks-matrix.sh
+++ b/.github/scripts/list-talks-matrix.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/find-talks.sh" | jq -R -s '
+  split("\n")
+  | map(select(length > 0))
+  | map({
+      dir: .,
+      name: (
+        . | ltrimstr("./")
+          | sub("^\\s+"; "")
+          | gsub("/"; "-")
+      )
+    })
+  | {include: .}
+'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ on:
       - ".junie/**"
       - ".skillfile/**"
 
+permissions:
+  contents: read
+
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,8 +9,6 @@ on:
       - ".claude/**"
       - ".junie/**"
       - ".skillfile/**"
-  push:
-    branches: [ci/pr-integration-build]
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,8 @@ on:
       - ".claude/**"
       - ".junie/**"
       - ".skillfile/**"
+  push:
+    branches: [ci/pr-integration-build]
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,46 @@
+name: Integration
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - "**.md"
+      - ".idea/**"
+      - ".claude/**"
+      - ".junie/**"
+      - ".skillfile/**"
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: list
+        run: echo "matrix=$(.github/scripts/list-talks-matrix.sh | jq -c .)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ${{ matrix.dir }}/package-lock.json
+
+      - run: .github/scripts/build-talk.sh "${{ matrix.dir }}" "${{ runner.temp }}/cache"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: talk-${{ matrix.name }}
+          path: ${{ matrix.dir }}/dist
+          retention-days: 7


### PR DESCRIPTION
## Summary
Adds `.github/workflows/integration.yml`, a PR-triggered CI workflow that discovers every Slidev talk deck in the repo and builds each one in an isolated matrix job. Today only `deploy.yml` builds anything, and only on push to `master` — Dependabot PRs bumping deck dependencies (vite, @slidev/cli, etc.) currently merge without any build validation. This closes that gap.

## Changes
- `.github/workflows/integration.yml` — new workflow, triggers on `pull_request` to `master` (paths-ignore for docs/config dirs). `discover` job builds a JSON matrix of talk decks; `build` job matrix-builds each deck in parallel via the existing `build-talk.sh` and uploads `dist/` as a 7-day-retention artifact.
- `.github/scripts/list-talks-matrix.sh` — new script wrapping the existing `find-talks.sh` to emit a sanitized JSON matrix via `jq`. Handles the one talk dir with a leading space and nested path (`" csharp/language/abstractions/composition"`) by deriving an artifact-safe `name` (space stripped, `/` replaced with `-`) while preserving the real `dir` path for checkout-relative use.

No changes to `deploy.yml`, `find-talks.sh`, or `build-talk.sh` — all reused as-is.

## Test Plan
- [x] Dry-ran `list-talks-matrix.sh` locally and confirmed it emits valid JSON, including correct handling of the leading-space/nested-path deck
- [ ] Confirm the `discover` and `build` jobs run green on this PR's own CI check
- [ ] Confirm one deck's `dist/` artifact is uploaded and downloadable from the Actions run